### PR TITLE
複数行テキスト貼り付け対応

### DIFF
--- a/src/interfaces/cli/components/utilities/inputNormalization.ts
+++ b/src/interfaces/cli/components/utilities/inputNormalization.ts
@@ -1,0 +1,39 @@
+export interface ChunkNormalizer {
+  normalize: (chunk: string) => string;
+  reset: () => void;
+}
+
+// Factory that returns a normalizer which:
+// - Removes bracketed paste markers (\x1b[200~ / \x1b[201~)
+// - Absorbs CRLF splits across chunks (prev ends with \r and next starts with \n)
+// - Converts remaining CR to LF
+export const createChunkNormalizer = (): ChunkNormalizer => {
+  let lastEndedWithCR = false;
+
+  return {
+    normalize: (raw: string): string => {
+      let chunk = raw;
+      // Strip bracketed paste markers if present
+      chunk = chunk.replace(/\x1b\[200~|\x1b\[201~/g, '');
+      // Collapse CRLF within the same chunk to a single LF
+      chunk = chunk.replace(/\r\n/g, '\n');
+
+      // If previous chunk ended with CR and this starts with LF, drop leading LF
+      if (lastEndedWithCR && chunk.startsWith('\n')) {
+        chunk = chunk.slice(1);
+      }
+
+      // Track CR at end before replacement
+      const endsWithCR = chunk.endsWith('\r');
+      // Normalize CR -> LF
+      chunk = chunk.replace(/\r/g, '\n');
+
+      // Update state for next call
+      lastEndedWithCR = endsWithCR;
+      return chunk;
+    },
+    reset: () => {
+      lastEndedWithCR = false;
+    }
+  };
+};


### PR DESCRIPTION
codex
**変更の要点**
- 入力の安定化: 複数チャンクに分割される貼り付け入力でも欠落しないよう、状態更新
を関数型に統一。
- 端末制御の無害化: Bracketed Paste の制御シーケンスを除去し、Ink の描画を乱さな
いようにした。
- ログの撤去: 画面描画を乱す console.log を全削除（入力処理中・レンダー中とも）
。

**技術的な詳細**
- 関数型更新: `onInputChange(prev => prev + chunk)` / `prev.slice(0, -1)` に統一
し、貼り付けチャンクが高速連続しても最新の state に累積。
- CRLF吸収: `useRef` で直前チャンクが `\r` で終わったかを保持。次チャンク先頭が 
`\n` なら落として結合し、残る `\r` は `\n` に正規化。
- Bracketed Paste対応: 端末が貼り付け時に挿入する `\x1b[200~` / `\x1b[201~` を除
去して無害化。
- ログ削除: `useInput` 先頭の生ログや、レンダー中のデバッグ出力を完全に撤去して
、Ink の再描画と干渉しないようにした。

- 先頭が欠落したり途中から表示される不具合を解消。
- 端末制御シーケンスや CR による行頭戻りでの上書きを防止。
